### PR TITLE
Revert "Resolving Claim Handling issue"

### DIFF
--- a/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/AttributeCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/AttributeCallbackHandler.java
@@ -141,6 +141,12 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
                             applicationManagementService.getServiceProviderByClientId(endPointReference, "wstrust",
                                     tenantDomain);
                     ClaimMapping[] claimMappings = serviceProvider.getClaimConfig().getClaimMappings();
+                    if (claimMappings.length == 0) {
+                        SAMLAttribute attribute = new SAMLAttribute("Name",
+                                "https://rahas.apache.org/saml/attrns", null, -1, Arrays
+                                .asList(new String[]{"Colombo/Rahas"}));
+                        attrCallback.addAttributes(attribute);
+                    }
                     for (int i = 0; i < claimMappings.length; i++) {
                         String localClaimUri = claimMappings[i].getLocalClaim().getClaimUri();
                         String remoteClaimUri = claimMappings[i].getRemoteClaim().getClaimUri();


### PR DESCRIPTION
Rampart expects attributes and always adds the attribute statement to the assertion. Assertion with an empty attribute statement fails when signed. Therefore this should be properly addressed within rampart
