### PR TITLE
Embed OpenSAML2 dependencies.

### DIFF
--- a/components/org.wso2.carbon.identity.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.provider/pom.xml
@@ -155,7 +155,6 @@
 
                             org.w3c.dom,
                             org.joda.time;version="${joda.wso2.osgi.version.range}",
-                            org.opensaml.*; version="${opensaml2.wso2.osgi.version.range}",
                             org.openid4java.*; version="${openid4java.wso2.osgi.version.range}",
 
                             org.apache.rahas.*; version="${rampart.wso2.osgi.version.range}",
@@ -200,6 +199,7 @@
                             !org.wso2.carbon.identity.provider.internal,
                             org.wso2.carbon.identity.provider.*; version="${identity.inbound.auth.openid.exp.pkg.version}"
                         </Export-Package>
+                        <Embed-Dependency>opensaml;inline=false</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>

--- a/features/org.wso2.carbon.identity.provider.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.provider.server.feature/pom.xml
@@ -129,7 +129,6 @@
                             <bundles>
                                 <bundleDef>org.wso2.carbon.identity.inbound.auth.openid:org.wso2.carbon.identity.provider</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.openid4java:openid4java</bundleDef>
-                                <bundleDef>org.wso2.orbit.org.opensaml:opensaml</bundleDef>
                                 <bundleDef>org.wso2.orbit.joda-time:joda-time</bundleDef>
                                 <bundleDef>net.sf.ehcache.wso2:ehcache</bundleDef>
                                 <bundleDef>net.minidev:json-smart</bundleDef>

--- a/pom.xml
+++ b/pom.xml
@@ -403,8 +403,8 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
+        <carbon.identity.framework.version>5.15.56-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon component version-->
         <carbon.base.imp.pkg.version.range>[1.0.0, 2.0.0)</carbon.base.imp.pkg.version.range>
@@ -423,11 +423,11 @@
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
 
         <!-- Rampart version -->
-        <rampart.wso2.version>1.6.1-wso2v36</rampart.wso2.version>
+        <rampart.wso2.version>1.6.1-wso2v42-SNAPSHOT</rampart.wso2.version>
         <rampart.wso2.osgi.version.range>[1.6.1,2.0.0)</rampart.wso2.osgi.version.range>
 
         <!-- WSS4j version -->
-        <wss4j.version>1.5.11.wso2v14</wss4j.version>
+        <wss4j.version>1.5.11-wso2v18-SNAPSHOT</wss4j.version>
         <wss4j.ws.security.imp.pkg.version.range>[1.5.11,2.0.0)</wss4j.ws.security.imp.pkg.version.range>
         <wss4j.xml.security.imp.pkg.version.range>[1.4.2.patched,2.0.0)</wss4j.xml.security.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -403,7 +403,7 @@
         <carbon.kernel.registry.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.kernel.registry.imp.pkg.version.range>
 
         <!-- Carbon Identity Framework version -->
-        <carbon.identity.framework.version>5.15.56-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.15.62</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.15.0, 6.0.0)</carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon component version-->
@@ -423,11 +423,11 @@
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
 
         <!-- Rampart version -->
-        <rampart.wso2.version>1.6.1-wso2v42-SNAPSHOT</rampart.wso2.version>
+        <rampart.wso2.version>1.6.1-wso2v42</rampart.wso2.version>
         <rampart.wso2.osgi.version.range>[1.6.1,2.0.0)</rampart.wso2.osgi.version.range>
 
         <!-- WSS4j version -->
-        <wss4j.version>1.5.11-wso2v18-SNAPSHOT</wss4j.version>
+        <wss4j.version>1.5.11-wso2v19</wss4j.version>
         <wss4j.ws.security.imp.pkg.version.range>[1.5.11,2.0.0)</wss4j.ws.security.imp.pkg.version.range>
         <wss4j.xml.security.imp.pkg.version.range>[1.4.2.patched,2.0.0)</wss4j.xml.security.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Embed OpenSAML2 dependencies to remove exposure of OpenSAML2 orbit to product-is.

### Prerequisites

- https://github.com/wso2/wso2-wss4j/pull/80 - wss4j with embedded OpenSAML2 dependencies.
- https://github.com/wso2/wso2-rampart/pull/101 - rampart with embedded OpenSAML2 dependencies.
- https://github.com/wso2/carbon-identity-framework/pull/2632 - identity framework with conflicting OpenSAML2 dependencies removed.

Fixes: wso2/product-is#7156