### PR TITLE
Fix user identifier for WS-Trust STS flow

### DIFF
--- a/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/AttributeCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/AttributeCallbackHandler.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.StringTokenizer;
 
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.AUTHENTICATED_USER;
+import static org.wso2.carbon.user.core.UserCoreConstants.DEFAULT_PROFILE;
 import static org.wso2.carbon.utils.multitenancy.MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
 public class AttributeCallbackHandler implements SAMLCallbackHandler {
@@ -151,7 +152,7 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
                                 if (isHandlerCalledFromWSTrustSTSFlow(attrCallback)) {
                                     localClaimValue = IdentityProviderServiceComponent.getRealmService().
                                             getBootstrapRealm().getUserStoreManager().
-                                            getUserClaimValue(userIdentifier, localClaimUri, "default");
+                                            getUserClaimValue(userIdentifier, localClaimUri, DEFAULT_PROFILE);
                                 } else if(!authenticatedUser.isFederatedUser()) {
                                     if (log.isDebugEnabled()) {
                                         log.debug("Loading claim values from local UserStore for user: "
@@ -159,7 +160,7 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
                                     }
                                     localClaimValue = IdentityProviderServiceComponent.getRealmService().
                                             getBootstrapRealm().getUserStoreManager().
-                                            getUserClaimValue(userIdentifier, localClaimUri, "default");
+                                            getUserClaimValue(userIdentifier, localClaimUri, DEFAULT_PROFILE);
                                 }
 
                                 if (StringUtils.isEmpty(localClaimValue)) {
@@ -439,11 +440,13 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
     protected RequestedClaimData getRequestedClaim() {
         return new RequestedClaimData();
     }
-    
+
     private boolean isHandlerCalledFromWSTrustSTSFlow(SAMLAttributeCallback attributeCallback) {
         
-        // Authenticated user property is properly set during a passive STS flow. It is not done in the WS Trust based
-        // flow.
+        /*
+        Authenticated user property is properly set during a passive STS flow. It is not done in the WS Trust based
+        flow.
+         */
         return !(attributeCallback.getData().getInMessageContext().getProperty(AUTHENTICATED_USER) instanceof
                 AuthenticatedUser);
     }

--- a/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/AttributeCallbackHandler.java
+++ b/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/AttributeCallbackHandler.java
@@ -404,7 +404,7 @@ public class AttributeCallbackHandler implements SAMLCallbackHandler {
                         } else {
                             nameSpace = claimData.getUri();
                             if (nameSpace.contains("/") && nameSpace.length() > (nameSpace.lastIndexOf("/") + 1)) {
-                                // Custom claim uri should be in a format of http(s)://nameSpace/name
+                                // Custom claim uri should be in a format of http(s)://nameSpace/name.
                                 name = nameSpace.substring(nameSpace.lastIndexOf("/") + 1);
                                 nameSpace = nameSpace.substring(0, nameSpace.lastIndexOf("/"));
                             } else {


### PR DESCRIPTION
Fixes wso2/product-is#8352.

Fix for the issue: wso2/product-is#4282 assumes that the user identifier is set as a thread-local variable, during the passive STS flow. With the merged fix, everything works fine with passive STS.

However, the WS-Trust STS flow does not take the user identifier from this tread-local variable thus causing NPEs.

This PR checks for the token issuing flow(whether it's passive STS, or not), and switch back to the default flow for WS-Trust STS.