### PR TITLE
Remove SHA1 default usage

### DIFF
--- a/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/OpenIDProviderService.java
+++ b/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/OpenIDProviderService.java
@@ -599,7 +599,7 @@ public class OpenIDProviderService {
             rpdo.setTrustedAlways(rpdto.isTrustedAlways());
             rpdo.setDefaultProfileName(rpdto.getDefaultProfileName());
 
-            MessageDigest sha = MessageDigest.getInstance("SHA-1");
+            MessageDigest sha = MessageDigest.getInstance("SHA-256");
             byte[] digest = sha.digest((userName + ":" + rpdto.getRpUrl()).getBytes());
             rpdo.setUuid(new String(Hex.encodeHex(digest)));
 

--- a/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/OpenIDServerAssociationStore.java
+++ b/components/org.wso2.carbon.identity.provider/src/main/java/org/wso2/carbon/identity/provider/openid/OpenIDServerAssociationStore.java
@@ -42,7 +42,7 @@ import java.util.Date;
 public class OpenIDServerAssociationStore extends InMemoryServerAssociationStore {
 
     private static final Log log = LogFactory.getLog(OpenIDServerAssociationStore.class);
-    private static final String SHA_1_PRNG = "SHA1PRNG";
+    private static final String DRBG = "DRBG";
     private int storeId = 0;
     private String timestamp;
     private int counter;
@@ -57,10 +57,10 @@ public class OpenIDServerAssociationStore extends InMemoryServerAssociationStore
      */
     public OpenIDServerAssociationStore(String associationsType) {
         try {
-            SecureRandom secureRandom = SecureRandom.getInstance(SHA_1_PRNG);
+            SecureRandom secureRandom = SecureRandom.getInstance(DRBG);
             storeId = secureRandom.nextInt(9999);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA1PRNG algorithm could not be found.", e);
+            throw new RuntimeException("DRBG algorithm could not be found.", e);
         }
         timestamp = Long.toString(new Date().getTime());
         counter = 0;


### PR DESCRIPTION
## Proposed changes in this pull request

The default behavior of our products uses SHA1 which is no longer considered as secure. This PR changes the default usage to SHA256 in the following flows.
- updateOpenIDUserRPInfo() method will use SHA-256
- Secure Random generation will use DRBG algorithm

## Related issues
 
- Issue https://github.com/wso2/product-is/issues/15793

## Related PRs

- PR https://github.com/wso2/carbon-identity-framework/pull/4567
- PR https://github.com/wso2-extensions/identity-outbound-auth-samlsso/pull/162
- PR https://github.com/wso2-extensions/identity-inbound-auth-sts/pull/136
- PR https://github.com/wso2-extensions/identity-metadata-saml2/pull/85
- PR https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2076
- PR https://github.com/wso2/cipher-tool/pull/78
- PR https://github.com/wso2/carbon-kernel/pull/3574
- PR https://github.com/wso2-extensions/identity-user-account-association/pull/47
- PR https://github.com/wso2-enterprise/asgardeo-website/pull/639
- PR https://github.com/wso2-extensions/identity-governance/pull/707
- PR https://github.com/wso2-extensions/identity-outbound-auth-sms-otp/pull/173
- PR https://github.com/wso2-extensions/identity-outbound-auth-email-otp/pull/157

## Documentation

- PR https://github.com/wso2/docs-is/pull/3717
