### PR TITLE
Upgrade net.minidev.accessors-smart to v2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
         <json-smart.version>2.4.10</json-smart.version>
         <tomcat-servlet-api.version>7.0.81.wso2v1</tomcat-servlet-api.version>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>
-        <net.minidev.accessors-smart.version>2.4.7</net.minidev.accessors-smart.version>
+        <net.minidev.accessors-smart.version>2.5.0</net.minidev.accessors-smart.version>
         <org.ow2.asm.asm.version>5.2</org.ow2.asm.asm.version>
         <org.ow2.asm.version>9.2</org.ow2.asm.version>
 


### PR DESCRIPTION
### Proposed changes in this pull request
This PR upgrades `net.minidev.accessors-smart` version from `2.4.7` to `2.5.0`.
