### PR TITLE
Upgrade json-smart version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,10 +354,10 @@
         <openid4java.wso2.osgi.version.range>[1.0.0,2.0.0)</openid4java.wso2.osgi.version.range>
 
         <ehcache.version>1.5.0.wso2v3</ehcache.version>
-        <json-smart.version>2.5.0</json-smart.version>
+        <json-smart.version>2.5.2</json-smart.version>
         <tomcat-servlet-api.version>7.0.81.wso2v1</tomcat-servlet-api.version>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>
-        <net.minidev.accessors-smart.version>2.5.0</net.minidev.accessors-smart.version>
+        <net.minidev.accessors-smart.version>2.5.2</net.minidev.accessors-smart.version>
         <org.ow2.asm.asm.version>5.2</org.ow2.asm.asm.version>
         <org.ow2.asm.version>9.2</org.ow2.asm.version>
 


### PR DESCRIPTION
### Purpose
To upgrade json-smart version from 2.5.0 to the non-vulnerable 2.5.2 version.

#### Related PRs:

Identity-inbound-auth-oauth: https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2730
Carbon-identity-framework: https://github.com/wso2/carbon-identity-framework/pull/6543
Identity-outbound-auth-oidc: https://github.com/wso2-extensions/identity-outbound-auth-oidc/pull/199
Carbon-mediation: https://github.com/wso2/carbon-mediation/pull/1767
Carbon-analytics-common: https://github.com/wso2/carbon-analytics-common/pull/862
Carbon-apimgt: https://github.com/wso2/carbon-apimgt/pull/12953
Product-apim: https://github.com/wso2/product-apim/pull/13688
