### PR TITLE
Dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
         <openid4java.wso2.osgi.version.range>[1.0.0,2.0.0)</openid4java.wso2.osgi.version.range>
 
         <ehcache.version>1.5.0.wso2v3</ehcache.version>
-        <json-smart.version>2.5.2</json-smart.version>
+        <json-smart.version>2.6.0</json-smart.version>
         <tomcat-servlet-api.version>7.0.81.wso2v1</tomcat-servlet-api.version>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>
         <net.minidev.accessors-smart.version>2.5.2</net.minidev.accessors-smart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
         <json-smart.version>2.6.0</json-smart.version>
         <tomcat-servlet-api.version>7.0.81.wso2v1</tomcat-servlet-api.version>
         <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>
-        <net.minidev.accessors-smart.version>2.5.2</net.minidev.accessors-smart.version>
+        <net.minidev.accessors-smart.version>2.6.0</net.minidev.accessors-smart.version>
         <org.ow2.asm.asm.version>5.2</org.ow2.asm.asm.version>
         <org.ow2.asm.version>9.2</org.ow2.asm.version>
 


### PR DESCRIPTION
This PR updates JSON processing libraries to their latest stable versions to improve security, performance, and compatibility.

### Changes Made

**JSON Processing Libraries:**
- **json-smart**: `2.5.2` → `2.6.0`
- **net.minidev.accessors-smart**: `2.5.2` → `2.6.0`

Related Issue: https://github.com/wso2/api-manager/issues/3870
