### PR TITLE
[5.9.x] Upgrade axis2 and axiom versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,11 @@
         <javax.xml.parsers.import.pkg.version>[0.0.0, 1.0.0)</javax.xml.parsers.import.pkg.version>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
-        <axis2.osgi.version.range>[1.6.1-wso2v105, 2.0.0)</axis2.osgi.version.range>
+        <axis2.wso2.version>1.6.1-wso2v108</axis2.wso2.version>
+        <axis2.osgi.version.range>[1.6.1, 2.0.0)</axis2.osgi.version.range>
 
         <!-- Axiom Version -->
-        <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
+        <axiom.wso2.version>1.2.11-wso2v30</axiom.wso2.version>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
 
         <!-- Commons -->


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates dependency versions in the `pom.xml` file to use newer releases of Axis2 and Axiom libraries. These changes help ensure compatibility with upstream improvements and bug fixes.

Dependency version updates:

* Updated `axis2.wso2.version` from `1.6.1-wso2v105` to `1.6.1-wso2v108` and relaxed `axis2.osgi.version.range` to start from `1.6.1` instead of the WSO2-specific version.
* Updated `axiom.wso2.version` from `1.2.11-wso2v29` to `1.2.11-wso2v30`.
